### PR TITLE
Add tests and formatting options to the `ronin ip` sub-command

### DIFF
--- a/lib/ronin/cli/commands/ip.rb
+++ b/lib/ronin/cli/commands/ip.rb
@@ -241,15 +241,13 @@ module Ronin
           if options[:hex]
             "0x%x" % ip.to_i 
           elsif options[:hex_octet]
-            octets = ip.to_s.split(".").map!(&:to_i)
-            octets.map { |octet| octet.to_s(16) }.join(".")
+            ip.to_s.split(".").map { |octet| octet.to_i.to_s(16) }.join(".")
           elsif options[:decimal]
             "%u" % ip.to_i
           elsif options[:octal]
-            to_octal(ip.to_i)
+            "0%o" % ip.to_i
           elsif options[:octal_octet]
-            octets = ip.to_s.split(".").map!(&:to_i)
-            octets.map { |octet| to_octal(octet) }.join(".")
+            ip.to_s.split(".").map { |octet| "0%o" % octet.to_i }.join(".")
           elsif options[:binary]
             "%b" % ip.to_i
           elsif options[:ipv6_compat]
@@ -257,12 +255,6 @@ module Ronin
           else
             ip.to_s
           end
-        end
-
-        private
-
-        def to_octal(n)
-          "0%o" % n
         end
 
       end

--- a/lib/ronin/cli/commands/ip.rb
+++ b/lib/ronin/cli/commands/ip.rb
@@ -251,7 +251,7 @@ module Ronin
           elsif options[:binary]
             "%b" % ip.to_i
           elsif options[:ipv6_compat]
-            IPAddr.new(ip.to_s).ipv4_mapped.to_s
+            ip.ipv4_mapped.to_s
           else
             ip.to_s
           end

--- a/lib/ronin/cli/commands/ip.rb
+++ b/lib/ronin/cli/commands/ip.rb
@@ -19,6 +19,7 @@
 require 'ronin/cli/value_processor_command'
 require 'ronin/support/network/ip'
 require 'uri'
+require 'ipaddr'
 
 module Ronin
   class CLI
@@ -40,6 +41,9 @@ module Ronin
       #     -D, --decimal                    Converts the IP address to decimal format
       #     -O, --octal                      Converts the IP address to octal format
       #     -B, --binary                     Converts the IP address to binary format
+      #         --hex-octet                  Converts the IP address to hexadecimal format by octet
+      #         --octal-octet                Converts the IP address to octal format by octet
+      #         --ipv6-compat                Converts the IP address to an IPv6 compatible address
       #     -C, --cidr NETMASK               Converts the IP address into a CIDR range
       #     -H, --host                       Converts the IP address to a host name
       #     -p, --port PORT                  Appends the port number to each IP
@@ -88,6 +92,15 @@ module Ronin
 
         option :binary, short: '-B',
                         desc:  'Converts the IP address to binary format'
+
+        option :hex_octet,
+                       desc: 'Converts the IP address to hexadecimal format by octet'
+        
+        option :octal_octet,
+                       desc: 'Converts the IP address to octal format by octet'
+        
+        option :ipv6_compat,
+                       desc: 'Converts the IP address to an IPv6 compatible address'
 
         option :cidr, short: '-C',
                       value: {
@@ -226,16 +239,30 @@ module Ronin
         #
         def format_ip(ip)
           if options[:hex]
-            "0x%x" % ip.to_i
+            "0x%x" % ip.to_i 
+          elsif options[:hex_octet]
+            octets = ip.to_s.split(".").map!(&:to_i)
+            octets.map { |octet| octet.to_s(16) }.join(".")
           elsif options[:decimal]
             "%u" % ip.to_i
           elsif options[:octal]
-            "0%o" % ip.to_i
+            to_octal(ip.to_i)
+          elsif options[:octal_octet]
+            octets = ip.to_s.split(".").map!(&:to_i)
+            octets.map { |octet| to_octal(octet) }.join(".")
           elsif options[:binary]
             "%b" % ip.to_i
+          elsif options[:ipv6_compat]
+            IPAddr.new(ip.to_s).ipv4_mapped.to_s
           else
             ip.to_s
           end
+        end
+
+        private
+
+        def to_octal(n)
+          "0%o" % n
         end
 
       end

--- a/lib/ronin/cli/commands/ip.rb
+++ b/lib/ronin/cli/commands/ip.rb
@@ -94,13 +94,13 @@ module Ronin
                         desc:  'Converts the IP address to binary format'
 
         option :hex_octet,
-                       desc: 'Converts the IP address to hexadecimal format by octet'
-        
+               desc: 'Converts the IP address to hexadecimal format by octet'
+
         option :octal_octet,
-                       desc: 'Converts the IP address to octal format by octet'
-        
+               desc: 'Converts the IP address to octal format by octet'
+
         option :ipv6_compat,
-                       desc: 'Converts the IP address to an IPv6 compatible address'
+               desc: 'Converts the IP address to an IPv6 compatible address'
 
         option :cidr, short: '-C',
                       value: {
@@ -239,7 +239,7 @@ module Ronin
         #
         def format_ip(ip)
           if options[:hex]
-            "0x%x" % ip.to_i 
+            "0x%x" % ip.to_i
           elsif options[:hex_octet]
             ip.to_s.split(".").map { |octet| octet.to_i.to_s(16) }.join(".")
           elsif options[:decimal]

--- a/spec/cli/commands/ip_spec.rb
+++ b/spec/cli/commands/ip_spec.rb
@@ -4,4 +4,63 @@ require_relative 'man_page_example'
 
 describe Ronin::CLI::Commands::Ip do
   include_examples "man_page"
+
+  let(:ipcmd) { Ronin::CLI::Commands::Ip.new}
+  let(:localhost) { "127.0.0.1" }
+
+  describe "-r" do
+    it "will reverse an IPv4 address" do
+      ipcmd.options[:reverse] = true
+      expect{ ipcmd.process_value(localhost) }.to output("1.0.0.127.in-addr.arpa\n").to_stdout
+    end
+  end
+
+  describe "--hex" do
+    it "will convert an IPv4 address to hexadecimal" do
+      ipcmd.options[:hex] = true
+      expect{ ipcmd.process_value(localhost) }.to output("0x7f000001\n").to_stdout
+    end
+  end
+
+  describe "--decimal" do
+    it "will convert an IPv4 address to decimal" do
+      ipcmd.options[:decimal] = true
+      expect{ ipcmd.process_value(localhost) }.to output("2130706433\n").to_stdout
+    end
+  end
+
+  describe "--octal" do
+    it "will convert an IPv4 address to octal" do
+      ipcmd.options[:octal] = true
+      expect{ ipcmd.process_value(localhost) }.to output("017700000001\n").to_stdout
+    end
+  end
+
+  describe "--binary" do
+    it "will convert an IPv4 address to binary" do
+      ipcmd.options[:binary] = true
+      expect{ ipcmd.process_value(localhost) }.to output("1111111000000000000000000000001\n").to_stdout
+    end
+  end
+
+  describe "--octal-octet" do
+    it "will convert an IPv4 address to octal by octet" do
+      ipcmd.options[:octal_octet] = true
+      expect{ ipcmd.process_value(localhost) }.to output("0177.00.00.01\n").to_stdout
+    end
+  end
+
+  describe "--hex-octet" do
+    it "will convert an IPv4 address to hex by octet" do
+      ipcmd.options[:hex_octet] = true
+      expect{ ipcmd.process_value(localhost) }.to output("7f.0.0.1\n").to_stdout
+    end
+  end
+
+  describe "--ipv6-compat" do
+    it "will convert an IPv4 address to an IPv6 compatible address" do
+      ipcmd.options[:ipv6_compat] = true
+      expect{ ipcmd.process_value(localhost) }.to output("::ffff:127.0.0.1\n").to_stdout
+    end
+  end
 end

--- a/spec/cli/commands/ip_spec.rb
+++ b/spec/cli/commands/ip_spec.rb
@@ -5,114 +5,111 @@ require_relative 'man_page_example'
 describe Ronin::CLI::Commands::Ip do
   include_examples "man_page"
 
-  subject { Ronin::CLI::Commands::Ip.new }
   let(:localhost) { "127.0.0.1" }
 
   describe "#process_value" do
-
-    describe "-r" do
+    describe "when -r option is given" do
       it "will reverse an IPv4 address" do
         subject.options[:reverse] = true
         expect{ subject.process_value(localhost) }.to output("1.0.0.127.in-addr.arpa\n").to_stdout
       end
     end
 
-    describe "--hex" do
+    describe "when --hex option is given" do
       it "will convert an IPv4 address to hexadecimal" do
         subject.options[:hex] = true
         expect{ subject.process_value(localhost) }.to output("0x7f000001\n").to_stdout
       end
     end
 
-    describe "--decimal" do
+    describe "when --decimal option is given" do
       it "will convert an IPv4 address to decimal" do
         subject.options[:decimal] = true
         expect{ subject.process_value(localhost) }.to output("2130706433\n").to_stdout
       end
     end
 
-    describe "--octal" do
+    describe "when --octal option is given" do
       it "will convert an IPv4 address to octal" do
         subject.options[:octal] = true
         expect{ subject.process_value(localhost) }.to output("017700000001\n").to_stdout
       end
     end
 
-    describe "--binary" do
+    describe "when --binary option is given" do
       it "will convert an IPv4 address to binary" do
         subject.options[:binary] = true
         expect{ subject.process_value(localhost) }.to output("1111111000000000000000000000001\n").to_stdout
       end
     end
 
-    describe "--octal-octet" do
+    describe "when --octal-octet option is given" do
       it "will convert an IPv4 address to octal by octet" do
         subject.options[:octal_octet] = true
         expect{ subject.process_value(localhost) }.to output("0177.00.00.01\n").to_stdout
       end
     end
 
-    describe "--hex-octet" do
+    describe "when --hex-octet option is given" do
       it "will convert an IPv4 address to hex by octet" do
         subject.options[:hex_octet] = true
         expect{ subject.process_value(localhost) }.to output("7f.0.0.1\n").to_stdout
       end
     end
 
-    describe "--ipv6-compat" do
+    describe "when --ipv6-compat option is given" do
       it "will convert an IPv4 address to an IPv6 compatible address" do
         subject.options[:ipv6_compat] = true
         expect{ subject.process_value(localhost) }.to output("::ffff:127.0.0.1\n").to_stdout
       end
     end
-    
+
   end
 
   describe "#format_ip" do
-
-    describe "--hex" do
+    describe "when options[:hex] is present" do
       it "will convert an IPv4 address to hexadecimal" do
         subject.options[:hex] = true
         expect(subject.format_ip(localhost)).to eq("0x7f")
       end
     end
 
-    describe "--decimal" do
+    describe "when options[:decimal] is present" do
       it "will convert an IPv4 address to decimal" do
         subject.options[:decimal] = true
         expect(subject.format_ip(localhost)).to eq("127")
       end
     end
 
-    describe "--octal" do
+    describe "when options[:octal] is present" do
       it "will convert an IPv4 address to octal" do
         subject.options[:octal] = true
         expect(subject.format_ip(localhost)).to eq("0177")
       end
     end
 
-    describe "--binary" do
+    describe "when options[:binary] is present" do
       it "will convert an IPv4 address to binary" do
         subject.options[:binary] = true
         expect(subject.format_ip(localhost)).to eq("1111111")
       end
     end
 
-    describe "--octal-octet" do
+    describe "when options[:octal_octet] is present" do
       it "will convert an IPv4 address to octal by octet" do
         subject.options[:octal_octet] = true
         expect(subject.format_ip(localhost)).to eq("0177.00.00.01")
       end
     end
 
-    describe "--hex-octet" do
+    describe "when options[:hex_octet] is present" do
       it "will convert an IPv4 address to hex by octet" do
         subject.options[:hex_octet] = true
         expect(subject.format_ip(localhost)).to eq("7f.0.0.1")
       end
     end
 
-    describe "--ipv6-compat" do
+    describe "when options[:ipv6_compat] is present" do
       it "will convert an IPv4 address to an IPv6 compatible address" do
         subject.options[:ipv6_compat] = true
         expect(subject.format_ip(localhost)).to eq("::ffff:127.0.0.1")

--- a/spec/cli/commands/ip_spec.rb
+++ b/spec/cli/commands/ip_spec.rb
@@ -8,58 +8,66 @@ describe Ronin::CLI::Commands::Ip do
   let(:localhost) { "127.0.0.1" }
 
   describe "#process_value" do
-    describe "when -r option is given" do
+    context "when -r option is given" do
+      before { subject.options[:reverse] = true }
+
       it "will reverse an IPv4 address" do
-        subject.options[:reverse] = true
         expect{ subject.process_value(localhost) }.to output("1.0.0.127.in-addr.arpa\n").to_stdout
       end
     end
 
-    describe "when --hex option is given" do
+    context "when --hex option is given" do
+      before { subject.options[:hex] = true }
+
       it "will convert an IPv4 address to hexadecimal" do
-        subject.options[:hex] = true
         expect{ subject.process_value(localhost) }.to output("0x7f000001\n").to_stdout
       end
     end
 
-    describe "when --decimal option is given" do
+    context "when --decimal option is given" do
+      before { subject.options[:decimal] = true }
+
       it "will convert an IPv4 address to decimal" do
-        subject.options[:decimal] = true
         expect{ subject.process_value(localhost) }.to output("2130706433\n").to_stdout
       end
     end
 
-    describe "when --octal option is given" do
+    context "when --octal option is given" do
+      before { subject.options[:octal] = true }
+
       it "will convert an IPv4 address to octal" do
-        subject.options[:octal] = true
         expect{ subject.process_value(localhost) }.to output("017700000001\n").to_stdout
       end
     end
 
-    describe "when --binary option is given" do
+    context "when --binary option is given" do
+      before { subject.options[:binary] = true }
+
       it "will convert an IPv4 address to binary" do
-        subject.options[:binary] = true
         expect{ subject.process_value(localhost) }.to output("1111111000000000000000000000001\n").to_stdout
       end
     end
 
-    describe "when --octal-octet option is given" do
+    context "when --octal-octet option is given" do
+      before { subject.options[:octal_octet] = true }
+
       it "will convert an IPv4 address to octal by octet" do
-        subject.options[:octal_octet] = true
         expect{ subject.process_value(localhost) }.to output("0177.00.00.01\n").to_stdout
       end
     end
 
-    describe "when --hex-octet option is given" do
+    context "when --hex-octet option is given" do
+      before { subject.options[:hex_octet] = true }
+
       it "will convert an IPv4 address to hex by octet" do
-        subject.options[:hex_octet] = true
         expect{ subject.process_value(localhost) }.to output("7f.0.0.1\n").to_stdout
       end
     end
 
-    describe "when --ipv6-compat option is given" do
+    context "when --ipv6-compat option is given" do
+      before { subject.options[:ipv6_compat] = true }
+
       it "will convert an IPv4 address to an IPv6 compatible address" do
-        subject.options[:ipv6_compat] = true
         expect{ subject.process_value(localhost) }.to output("::ffff:127.0.0.1\n").to_stdout
       end
     end
@@ -67,52 +75,61 @@ describe Ronin::CLI::Commands::Ip do
   end
 
   describe "#format_ip" do
-    describe "when options[:hex] is present" do
+    let(:ip) { Ronin::Support::Network::IP.new(localhost) }
+
+    context "when options[:hex] is present" do
+      before { subject.options[:hex] = true }
+
       it "will convert an IPv4 address to hexadecimal" do
-        subject.options[:hex] = true
-        expect(subject.format_ip(localhost)).to eq("0x7f")
+        expect(subject.format_ip(ip)).to eq("0x7f000001")
       end
     end
 
-    describe "when options[:decimal] is present" do
+    context "when options[:decimal] is present" do
+      before { subject.options[:decimal] = true }
+
       it "will convert an IPv4 address to decimal" do
-        subject.options[:decimal] = true
-        expect(subject.format_ip(localhost)).to eq("127")
+        expect(subject.format_ip(ip)).to eq("2130706433")
       end
     end
 
-    describe "when options[:octal] is present" do
+    context "when options[:octal] is present" do
+      before { subject.options[:octal] = true }
+      
       it "will convert an IPv4 address to octal" do
-        subject.options[:octal] = true
-        expect(subject.format_ip(localhost)).to eq("0177")
+        expect(subject.format_ip(ip)).to eq("017700000001")
       end
     end
 
-    describe "when options[:binary] is present" do
+    context "when options[:binary] is present" do
+      before { subject.options[:binary] = true }
+
       it "will convert an IPv4 address to binary" do
-        subject.options[:binary] = true
-        expect(subject.format_ip(localhost)).to eq("1111111")
+        expect(subject.format_ip(ip)).to eq("1111111000000000000000000000001")
       end
     end
 
-    describe "when options[:octal_octet] is present" do
+    context "when options[:octal_octet] is present" do
+      before { subject.options[:octal_octet] = true }
+
       it "will convert an IPv4 address to octal by octet" do
-        subject.options[:octal_octet] = true
-        expect(subject.format_ip(localhost)).to eq("0177.00.00.01")
+        expect(subject.format_ip(ip)).to eq("0177.00.00.01")
       end
     end
 
-    describe "when options[:hex_octet] is present" do
+    context "when options[:hex_octet] is present" do
+      before { subject.options[:hex_octet] = true }
+
       it "will convert an IPv4 address to hex by octet" do
-        subject.options[:hex_octet] = true
-        expect(subject.format_ip(localhost)).to eq("7f.0.0.1")
+        expect(subject.format_ip(ip)).to eq("7f.0.0.1")
       end
     end
 
-    describe "when options[:ipv6_compat] is present" do
+    context "when options[:ipv6_compat] is present" do
+      before { subject.options[:ipv6_compat] = true }
+
       it "will convert an IPv4 address to an IPv6 compatible address" do
-        subject.options[:ipv6_compat] = true
-        expect(subject.format_ip(localhost)).to eq("::ffff:127.0.0.1")
+        expect(subject.format_ip(ip)).to eq("::ffff:127.0.0.1")
       end
     end
 

--- a/spec/cli/commands/ip_spec.rb
+++ b/spec/cli/commands/ip_spec.rb
@@ -12,7 +12,7 @@ describe Ronin::CLI::Commands::Ip do
       before { subject.options[:reverse] = true }
 
       it "will reverse an IPv4 address" do
-        expect{ subject.process_value(localhost) }.to output("1.0.0.127.in-addr.arpa\n").to_stdout
+        expect { subject.process_value(localhost) }.to output("1.0.0.127.in-addr.arpa\n").to_stdout
       end
     end
 
@@ -20,7 +20,7 @@ describe Ronin::CLI::Commands::Ip do
       before { subject.options[:hex] = true }
 
       it "will convert an IPv4 address to hexadecimal" do
-        expect{ subject.process_value(localhost) }.to output("0x7f000001\n").to_stdout
+        expect { subject.process_value(localhost) }.to output("0x7f000001\n").to_stdout
       end
     end
 
@@ -28,7 +28,7 @@ describe Ronin::CLI::Commands::Ip do
       before { subject.options[:decimal] = true }
 
       it "will convert an IPv4 address to decimal" do
-        expect{ subject.process_value(localhost) }.to output("2130706433\n").to_stdout
+        expect { subject.process_value(localhost) }.to output("2130706433\n").to_stdout
       end
     end
 
@@ -36,7 +36,7 @@ describe Ronin::CLI::Commands::Ip do
       before { subject.options[:octal] = true }
 
       it "will convert an IPv4 address to octal" do
-        expect{ subject.process_value(localhost) }.to output("017700000001\n").to_stdout
+        expect { subject.process_value(localhost) }.to output("017700000001\n").to_stdout
       end
     end
 
@@ -44,7 +44,7 @@ describe Ronin::CLI::Commands::Ip do
       before { subject.options[:binary] = true }
 
       it "will convert an IPv4 address to binary" do
-        expect{ subject.process_value(localhost) }.to output("1111111000000000000000000000001\n").to_stdout
+        expect { subject.process_value(localhost) }.to output("1111111000000000000000000000001\n").to_stdout
       end
     end
 
@@ -52,7 +52,7 @@ describe Ronin::CLI::Commands::Ip do
       before { subject.options[:octal_octet] = true }
 
       it "will convert an IPv4 address to octal by octet" do
-        expect{ subject.process_value(localhost) }.to output("0177.00.00.01\n").to_stdout
+        expect { subject.process_value(localhost) }.to output("0177.00.00.01\n").to_stdout
       end
     end
 
@@ -60,7 +60,7 @@ describe Ronin::CLI::Commands::Ip do
       before { subject.options[:hex_octet] = true }
 
       it "will convert an IPv4 address to hex by octet" do
-        expect{ subject.process_value(localhost) }.to output("7f.0.0.1\n").to_stdout
+        expect { subject.process_value(localhost) }.to output("7f.0.0.1\n").to_stdout
       end
     end
 
@@ -68,10 +68,9 @@ describe Ronin::CLI::Commands::Ip do
       before { subject.options[:ipv6_compat] = true }
 
       it "will convert an IPv4 address to an IPv6 compatible address" do
-        expect{ subject.process_value(localhost) }.to output("::ffff:127.0.0.1\n").to_stdout
+        expect { subject.process_value(localhost) }.to output("::ffff:127.0.0.1\n").to_stdout
       end
     end
-
   end
 
   describe "#format_ip" do
@@ -95,7 +94,7 @@ describe Ronin::CLI::Commands::Ip do
 
     context "when options[:octal] is present" do
       before { subject.options[:octal] = true }
-      
+
       it "will convert an IPv4 address to octal" do
         expect(subject.format_ip(ip)).to eq("017700000001")
       end
@@ -132,6 +131,5 @@ describe Ronin::CLI::Commands::Ip do
         expect(subject.format_ip(ip)).to eq("::ffff:127.0.0.1")
       end
     end
-
   end
 end

--- a/spec/cli/commands/ip_spec.rb
+++ b/spec/cli/commands/ip_spec.rb
@@ -5,62 +5,119 @@ require_relative 'man_page_example'
 describe Ronin::CLI::Commands::Ip do
   include_examples "man_page"
 
-  let(:ipcmd) { Ronin::CLI::Commands::Ip.new}
+  subject { Ronin::CLI::Commands::Ip.new }
   let(:localhost) { "127.0.0.1" }
 
-  describe "-r" do
-    it "will reverse an IPv4 address" do
-      ipcmd.options[:reverse] = true
-      expect{ ipcmd.process_value(localhost) }.to output("1.0.0.127.in-addr.arpa\n").to_stdout
+  describe "#process_value" do
+
+    describe "-r" do
+      it "will reverse an IPv4 address" do
+        subject.options[:reverse] = true
+        expect{ subject.process_value(localhost) }.to output("1.0.0.127.in-addr.arpa\n").to_stdout
+      end
     end
+
+    describe "--hex" do
+      it "will convert an IPv4 address to hexadecimal" do
+        subject.options[:hex] = true
+        expect{ subject.process_value(localhost) }.to output("0x7f000001\n").to_stdout
+      end
+    end
+
+    describe "--decimal" do
+      it "will convert an IPv4 address to decimal" do
+        subject.options[:decimal] = true
+        expect{ subject.process_value(localhost) }.to output("2130706433\n").to_stdout
+      end
+    end
+
+    describe "--octal" do
+      it "will convert an IPv4 address to octal" do
+        subject.options[:octal] = true
+        expect{ subject.process_value(localhost) }.to output("017700000001\n").to_stdout
+      end
+    end
+
+    describe "--binary" do
+      it "will convert an IPv4 address to binary" do
+        subject.options[:binary] = true
+        expect{ subject.process_value(localhost) }.to output("1111111000000000000000000000001\n").to_stdout
+      end
+    end
+
+    describe "--octal-octet" do
+      it "will convert an IPv4 address to octal by octet" do
+        subject.options[:octal_octet] = true
+        expect{ subject.process_value(localhost) }.to output("0177.00.00.01\n").to_stdout
+      end
+    end
+
+    describe "--hex-octet" do
+      it "will convert an IPv4 address to hex by octet" do
+        subject.options[:hex_octet] = true
+        expect{ subject.process_value(localhost) }.to output("7f.0.0.1\n").to_stdout
+      end
+    end
+
+    describe "--ipv6-compat" do
+      it "will convert an IPv4 address to an IPv6 compatible address" do
+        subject.options[:ipv6_compat] = true
+        expect{ subject.process_value(localhost) }.to output("::ffff:127.0.0.1\n").to_stdout
+      end
+    end
+    
   end
 
-  describe "--hex" do
-    it "will convert an IPv4 address to hexadecimal" do
-      ipcmd.options[:hex] = true
-      expect{ ipcmd.process_value(localhost) }.to output("0x7f000001\n").to_stdout
-    end
-  end
+  describe "#format_ip" do
 
-  describe "--decimal" do
-    it "will convert an IPv4 address to decimal" do
-      ipcmd.options[:decimal] = true
-      expect{ ipcmd.process_value(localhost) }.to output("2130706433\n").to_stdout
+    describe "--hex" do
+      it "will convert an IPv4 address to hexadecimal" do
+        subject.options[:hex] = true
+        expect(subject.format_ip(localhost)).to eq("0x7f")
+      end
     end
-  end
 
-  describe "--octal" do
-    it "will convert an IPv4 address to octal" do
-      ipcmd.options[:octal] = true
-      expect{ ipcmd.process_value(localhost) }.to output("017700000001\n").to_stdout
+    describe "--decimal" do
+      it "will convert an IPv4 address to decimal" do
+        subject.options[:decimal] = true
+        expect(subject.format_ip(localhost)).to eq("127")
+      end
     end
-  end
 
-  describe "--binary" do
-    it "will convert an IPv4 address to binary" do
-      ipcmd.options[:binary] = true
-      expect{ ipcmd.process_value(localhost) }.to output("1111111000000000000000000000001\n").to_stdout
+    describe "--octal" do
+      it "will convert an IPv4 address to octal" do
+        subject.options[:octal] = true
+        expect(subject.format_ip(localhost)).to eq("0177")
+      end
     end
-  end
 
-  describe "--octal-octet" do
-    it "will convert an IPv4 address to octal by octet" do
-      ipcmd.options[:octal_octet] = true
-      expect{ ipcmd.process_value(localhost) }.to output("0177.00.00.01\n").to_stdout
+    describe "--binary" do
+      it "will convert an IPv4 address to binary" do
+        subject.options[:binary] = true
+        expect(subject.format_ip(localhost)).to eq("1111111")
+      end
     end
-  end
 
-  describe "--hex-octet" do
-    it "will convert an IPv4 address to hex by octet" do
-      ipcmd.options[:hex_octet] = true
-      expect{ ipcmd.process_value(localhost) }.to output("7f.0.0.1\n").to_stdout
+    describe "--octal-octet" do
+      it "will convert an IPv4 address to octal by octet" do
+        subject.options[:octal_octet] = true
+        expect(subject.format_ip(localhost)).to eq("0177.00.00.01")
+      end
     end
-  end
 
-  describe "--ipv6-compat" do
-    it "will convert an IPv4 address to an IPv6 compatible address" do
-      ipcmd.options[:ipv6_compat] = true
-      expect{ ipcmd.process_value(localhost) }.to output("::ffff:127.0.0.1\n").to_stdout
+    describe "--hex-octet" do
+      it "will convert an IPv4 address to hex by octet" do
+        subject.options[:hex_octet] = true
+        expect(subject.format_ip(localhost)).to eq("7f.0.0.1")
+      end
     end
+
+    describe "--ipv6-compat" do
+      it "will convert an IPv4 address to an IPv6 compatible address" do
+        subject.options[:ipv6_compat] = true
+        expect(subject.format_ip(localhost)).to eq("::ffff:127.0.0.1")
+      end
+    end
+
   end
 end


### PR DESCRIPTION
- Add test coverage for `-r`, `--hex`, `--decimal`, and `--octal`
- Add `--hex-octet` with test
- Add `--octal-octet` with test
- Add `--ipv6-compat` with test