### PR TITLE
Address mixed IP list behavior and fix/extend IPv6 formatting options

### DIFF
--- a/lib/ronin/cli/commands/ip.rb
+++ b/lib/ronin/cli/commands/ip.rb
@@ -300,9 +300,7 @@ module Ronin
             exit(1)
           elsif options[:hex_octet]
             if ip.ipv4_mapped?
-              v6_compat_split    = ip.to_s.split(/(?<!\:)\:(?!\:)/) # split at the first single ":"
-              v6_compat_split[1] = ipv4_hex_octet(v6_compat_split[1])
-              v6_compat_split.join(":")
+              "::ffff:#{ipv4_hex_octet(ip.ipv4)}"
             else
               print_error "called with --hex-octet for #{ip}"
               exit(1)

--- a/lib/ronin/cli/commands/ip.rb
+++ b/lib/ronin/cli/commands/ip.rb
@@ -100,11 +100,9 @@ module Ronin
         option :octal_octet,
                desc: 'Converts the IP address to octal format by octet'
 
-        option :ipv6_compat,
-               desc: 'Converts the IPv4 address to an IPv6 compatible address'
+        option :ipv6_compat, desc: 'Converts the IPv4 address to an IPv6 compatible address'
 
-        option :ipv6_expanded,
-               desc: 'Expands a shortened or compressed IPv6 address'
+        option :ipv6_expanded, desc: 'Expands a shortened or compressed IPv6 address'
 
         option :cidr, short: '-C',
                       value: {
@@ -249,6 +247,15 @@ module Ronin
 
         private
 
+        #
+        # Formats an IPv4 address.
+        #
+        # @param [Ronin::Support::Network::IP] ip
+        #   The IP address to format.
+        #
+        # @return [String]
+        #   The formatted IP address.
+        #
         def format_ipv4(ip)
           if options[:hex]
             "0x%x" % ip.to_i
@@ -272,6 +279,15 @@ module Ronin
           end
         end
 
+        #
+        # Formats an IPv6 address.
+        #
+        # @param [Ronin::Support::Network::IP] ip
+        #   The IP address to format.
+        #
+        # @return [String]
+        #   The formatted IP address.
+        #
         def format_ipv6(ip)
           if options[:decimal]
             "%u" % ip.to_i
@@ -283,7 +299,6 @@ module Ronin
             print_error "called with --octal-octet for #{ip}"
             exit(1)
           elsif options[:hex_octet]
-            # if ip.to_s.match?(/^\:\:/)
             if ip.ipv4_mapped?
               v6_compat_split    = ip.to_s.split(/(?<!\:)\:(?!\:)/) # split at the first single ":"
               v6_compat_split[1] = ipv4_hex_octet(v6_compat_split[1])
@@ -304,6 +319,15 @@ module Ronin
           end
         end
 
+        #
+        # Converts the octets of an IP address to hex
+        #
+        # @param [Ronin::Support::Network::IP] ip
+        #   The IP address to convert.
+        #
+        # @return [String]
+        #   The formatted IP address.
+        #
         def ipv4_hex_octet(ip)
           ip.to_s.split(".").map { |octet| octet.to_i.to_s(16) }.join(".")
         end

--- a/man/ronin-ip.1.md
+++ b/man/ronin-ip.1.md
@@ -39,6 +39,18 @@ Queries or processes IP addresses.
 `-B`, `--binary`
   Converts the IP address to binary format.
 
+`--hex-octet`
+  Converts the IP address to hexadecimal format by octet
+
+`--octal-octet`
+  Converts the IP address to octal format by octet
+
+`--ipv6-compat`
+  Converts the IPv4 address to an IPv6 compatible address
+
+`--ipv6-expanded`
+  Expands a shortened or compressed IPv6 address
+
 `-C`, `--cidr` *NETMASK*
   Converts the IP address into a CIDR range.
 

--- a/spec/cli/commands/ip_spec.rb
+++ b/spec/cli/commands/ip_spec.rb
@@ -5,14 +5,21 @@ require_relative 'man_page_example'
 describe Ronin::CLI::Commands::Ip do
   include_examples "man_page"
 
-  let(:localhost) { "127.0.0.1" }
+  let(:localhost)          { "127.0.0.1" }
+  let(:localhost_v6)       { "::ffff:127.0.0.1" }
+  let(:localhost_v6_short) { "2001:db8:85a3::8a2e:370:7334" }
 
   describe "#process_value" do
     context "when -r option is given" do
       before { subject.options[:reverse] = true }
 
-      it "will reverse an IPv4 address" do
+      it "will convert and IPv4 address to reverse name format" do
         expect { subject.process_value(localhost) }.to output("1.0.0.127.in-addr.arpa\n").to_stdout
+      end
+
+      it "will convert and IPv6 address to reverse name format" do
+        expect { subject.process_value(localhost_v6) }.to \
+          output("1.0.0.0.0.0.f.7.f.f.f.f.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa\n").to_stdout
       end
     end
 
@@ -22,6 +29,10 @@ describe Ronin::CLI::Commands::Ip do
       it "will convert an IPv4 address to hexadecimal" do
         expect { subject.process_value(localhost) }.to output("0x7f000001\n").to_stdout
       end
+
+      it "will convert an IPv6 address" do
+        expect { subject.process_value(localhost_v6) }.to output("0xffff7f000001\n").to_stdout
+      end
     end
 
     context "when --decimal option is given" do
@@ -29,6 +40,10 @@ describe Ronin::CLI::Commands::Ip do
 
       it "will convert an IPv4 address to decimal" do
         expect { subject.process_value(localhost) }.to output("2130706433\n").to_stdout
+      end
+
+      it "will convert an IPv6 address" do
+        expect { subject.process_value(localhost_v6) }.to output("281472812449793\n").to_stdout
       end
     end
 
@@ -38,13 +53,23 @@ describe Ronin::CLI::Commands::Ip do
       it "will convert an IPv4 address to octal" do
         expect { subject.process_value(localhost) }.to output("017700000001\n").to_stdout
       end
+
+      it "will convert an IPv6 address to octal" do
+        expect { subject.process_value(localhost_v6) }.to output("07777757700000001\n").to_stdout
+      end
     end
 
     context "when --binary option is given" do
       before { subject.options[:binary] = true }
 
       it "will convert an IPv4 address to binary" do
-        expect { subject.process_value(localhost) }.to output("1111111000000000000000000000001\n").to_stdout
+        expect { subject.process_value(localhost) }.to \
+          output("1111111000000000000000000000001\n").to_stdout
+      end
+
+      it "will convert an IPv6 address to binary" do
+        expect { subject.process_value(localhost_v6) }.to \
+          output("111111111111111101111111000000000000000000000001\n").to_stdout
       end
     end
 
@@ -54,6 +79,17 @@ describe Ronin::CLI::Commands::Ip do
       it "will convert an IPv4 address to octal by octet" do
         expect { subject.process_value(localhost) }.to output("0177.00.00.01\n").to_stdout
       end
+
+      it "will complain about an IPv6 address" do
+        expect(subject).to receive(:print_error).with(
+          "called with --octal-octet for #{localhost_v6}"
+        )
+        expect {
+          subject.process_value(localhost_v6)
+        }.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(1)
+        end
+      end
     end
 
     context "when --hex-octet option is given" do
@@ -61,6 +97,21 @@ describe Ronin::CLI::Commands::Ip do
 
       it "will convert an IPv4 address to hex by octet" do
         expect { subject.process_value(localhost) }.to output("7f.0.0.1\n").to_stdout
+      end
+
+      it "will convert an IPv6 compatible IPv4 address" do
+        expect { subject.process_value(localhost_v6) }.to output("::ffff:7f.0.0.1\n").to_stdout
+      end
+
+      it "will complain about an IPv6 address" do
+        expect(subject).to receive(:print_error).with(
+          "called with --hex-octet for #{localhost_v6_short}"
+        )
+        expect {
+          subject.process_value(localhost_v6_short)
+        }.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(1)
+        end
       end
     end
 
@@ -70,17 +121,57 @@ describe Ronin::CLI::Commands::Ip do
       it "will convert an IPv4 address to an IPv6 compatible address" do
         expect { subject.process_value(localhost) }.to output("::ffff:127.0.0.1\n").to_stdout
       end
+
+      it "will complain about an IPv6 address" do
+        expect(subject).to receive(:print_error).with(
+          "called with --ipv6-compat for #{localhost_v6}"
+        )
+        expect {
+          subject.process_value(localhost_v6)
+        }.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(1)
+        end
+      end
+    end
+
+    context "when --ipv6-expanded option is given" do
+      before { subject.options[:ipv6_expanded] = true }
+
+      it "will complain about an IPv4 address" do
+        expect(subject).to receive(:print_error).with(
+          "called with --ipv6-expanded for #{localhost}"
+        )
+        expect {
+          subject.process_value(localhost)
+        }.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(1)
+        end
+      end
+
+      it "will expand a shortened or compressed IPv6 address" do
+        expect { subject.process_value(localhost_v6_short) }.to output("2001:0db8:85a3:0000:0000:8a2e:0370:7334\n").to_stdout
+      end
+
+      it "will expand an IPv6 compatible IPv4 address" do
+        expect { subject.process_value(localhost_v6) }.to output("0000:0000:0000:0000:0000:ffff:7f00:0001\n").to_stdout
+      end
     end
   end
 
   describe "#format_ip" do
-    let(:ip) { Ronin::Support::Network::IP.new(localhost) }
+    let(:ip)         { Ronin::Support::Network::IP.new(localhost) }
+    let(:ipv6)       { Ronin::Support::Network::IP.new(localhost_v6) }
+    let(:ipv6_short) { Ronin::Support::Network::IP.new(localhost_v6_short) }
 
     context "when options[:hex] is present" do
       before { subject.options[:hex] = true }
 
       it "will convert an IPv4 address to hexadecimal" do
         expect(subject.format_ip(ip)).to eq("0x7f000001")
+      end
+
+      it "will convert an IPv6 address" do
+        expect(subject.format_ip(ipv6)).to eq("0xffff7f000001")
       end
     end
 
@@ -90,6 +181,10 @@ describe Ronin::CLI::Commands::Ip do
       it "will convert an IPv4 address to decimal" do
         expect(subject.format_ip(ip)).to eq("2130706433")
       end
+
+      it "will convert an IPv6 address to decimal" do
+        expect(subject.format_ip(ipv6)).to eq("281472812449793")
+      end
     end
 
     context "when options[:octal] is present" do
@@ -98,6 +193,10 @@ describe Ronin::CLI::Commands::Ip do
       it "will convert an IPv4 address to octal" do
         expect(subject.format_ip(ip)).to eq("017700000001")
       end
+
+      it "will convert an IPv6 address to octal" do
+        expect(subject.format_ip(ipv6)).to eq("07777757700000001")
+      end
     end
 
     context "when options[:binary] is present" do
@@ -105,6 +204,11 @@ describe Ronin::CLI::Commands::Ip do
 
       it "will convert an IPv4 address to binary" do
         expect(subject.format_ip(ip)).to eq("1111111000000000000000000000001")
+      end
+
+      it "will convert an IPv6 address to binary" do
+        expect(subject.format_ip(ipv6)).to \
+          eq("111111111111111101111111000000000000000000000001")
       end
     end
 
@@ -122,6 +226,10 @@ describe Ronin::CLI::Commands::Ip do
       it "will convert an IPv4 address to hex by octet" do
         expect(subject.format_ip(ip)).to eq("7f.0.0.1")
       end
+
+      it "will convert an IPv6 compatible IPv4 address by octet" do
+        expect(subject.format_ip(ipv6)).to eq("::ffff:7f.0.0.1")
+      end
     end
 
     context "when options[:ipv6_compat] is present" do
@@ -129,6 +237,18 @@ describe Ronin::CLI::Commands::Ip do
 
       it "will convert an IPv4 address to an IPv6 compatible address" do
         expect(subject.format_ip(ip)).to eq("::ffff:127.0.0.1")
+      end
+    end
+
+    context "when --ipv6-expanded option is given" do
+      before { subject.options[:ipv6_expanded] = true }
+
+      it "will expand a shortened or compressed IPv6 address" do
+        expect(subject.format_ip(ipv6_short)).to eq("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+      end
+
+      it "will expand an IPv6 compatible IPv4 address" do
+        expect(subject.format_ip(ipv6)).to eq("0000:0000:0000:0000:0000:ffff:7f00:0001")
       end
     end
   end


### PR DESCRIPTION
- Fix handling of mixed IPv4/IPv6 addresses for `ronin ip`
- Update octal, hex, and decimal conversions for IPv6
- Raise errors for unexpected addresses
- Add `--hex-octet` for IPv6 compat IPv4 addresses
- Refactor #format_ip
- Add `--ipv6-expanded` option
- Update manpage and help output