### PR TITLE
 Add  spec for HttpListener in Ronin::CLI::Commands::New #252:

### DIFF
--- a/lib/ronin/cli/pattern_options.rb
+++ b/lib/ronin/cli/pattern_options.rb
@@ -116,19 +116,67 @@ module Ronin
       #
       def self.define_numeric_options(command)
         command.option :number, short: '-N',
-                                desc: 'Searches for all numbers' do
-                                  @pattern = NUMBER
-                                end
+                                desc: 'Searches for all numbers',
+                                value: {
+                                  type: Regexp,
+                                  value: NUMBER
+                                }
 
         command.option :hex_number, short: '-X',
-                                    desc: 'Searches for all hexadecimal numbers' do
-                                      @pattern = HEX_NUMBER
-                                    end
+                                    desc: 'Searches for all hexadecimal numbers',
+                                    value: {
+                                      type: Regexp,
+                                      value: HEX_NUMBER
+                                    }
 
         command.option :version_number, short: '-V',
-                                        desc: 'Searches for all version numbers' do
-                                          @pattern = VERSION_NUMBER
-                                        end
+                                        desc: 'Searches for all version numbers',
+                                        value: {
+                                          type: Regexp,
+                                          value: VERSION_NUMBER
+                                        }
+
+        command.option :alpha, desc: 'Searches for all alphabetic characters',
+                              value: {
+                                type: Regexp,
+                                value: /[a-zA-Z]+/
+                              }
+
+        command.option :uppercase, desc: 'Searches for all uppercase alphabetic characters',
+                                      value: {
+                                        type: Regexp,
+                                        value: /[A-Z]+/
+                                      }
+
+        command.option :lowercase, desc: 'Searches for all lowercase alphabetic characters',
+                                      value: {
+                                        type: Regexp,
+                                        value: /[a-z]+/
+                                      }
+
+        command.option :alpha_numeric, desc: 'Searches for all alphanumeric characters',
+                                       value: {
+                                         type: Regexp,
+                                         value: /[0-9a-zA-Z]+/
+                                       }
+
+        command.option :hex, desc: 'Searches for all hexadecimal characters',
+                              value: {
+                                type: Regexp,
+                                value: /[0-9a-fA-F]+/
+                              }
+
+        command.option :uppercase_hex, desc: 'Searches for all uppercase hexadecimal characters',
+                                     value: {
+                                       type: Regexp,
+                                       value: /[0-9A-F]+/
+                                     }
+
+        command.option :lowercase_hex, desc: 'Searches for all lowercase hexadecimal characters',
+                                     value: {
+                                       type: Regexp,
+                                       value: /[0-9a-f]+/
+                                     }
       end
 
       #

--- a/lib/ronin/cli/pattern_options.rb
+++ b/lib/ronin/cli/pattern_options.rb
@@ -116,67 +116,47 @@ module Ronin
       #
       def self.define_numeric_options(command)
         command.option :number, short: '-N',
-                                desc: 'Searches for all numbers',
-                                value: {
-                                  type: Regexp,
-                                  value: NUMBER
-                                }
+                                desc: 'Searches for all numbers' do
+          @pattern = NUMBER
+        end
 
         command.option :hex_number, short: '-X',
-                                    desc: 'Searches for all hexadecimal numbers',
-                                    value: {
-                                      type: Regexp,
-                                      value: HEX_NUMBER
-                                    }
+                                    desc: 'Searches for all hexadecimal numbers' do
+          @pattern = HEX_NUMBER
+        end
 
         command.option :version_number, short: '-V',
-                                        desc: 'Searches for all version numbers',
-                                        value: {
-                                          type: Regexp,
-                                          value: VERSION_NUMBER
-                                        }
+                                        desc: 'Searches for all version numbers' do
+          @pattern = VERSION_NUMBER
+        end
 
-        command.option :alpha, desc: 'Searches for all alphabetic characters',
-                              value: {
-                                type: Regexp,
-                                value: /[a-zA-Z]+/
-                              }
+        command.option :alpha, desc: 'Searches for all alphabetic characters' do
+          @pattern = /[a-zA-Z]+/
+        end
 
-        command.option :uppercase, desc: 'Searches for all uppercase alphabetic characters',
-                                      value: {
-                                        type: Regexp,
-                                        value: /[A-Z]+/
-                                      }
+        command.option :uppercase, desc: 'Searches for all uppercase alphabetic characters' do
+          @pattern = /[A-Z]+/
+        end
 
-        command.option :lowercase, desc: 'Searches for all lowercase alphabetic characters',
-                                      value: {
-                                        type: Regexp,
-                                        value: /[a-z]+/
-                                      }
+        command.option :lowercase, desc: 'Searches for all lowercase alphabetic characters' do
+          @pattern = /[a-z]+/
+        end
 
-        command.option :alpha_numeric, desc: 'Searches for all alphanumeric characters',
-                                       value: {
-                                         type: Regexp,
-                                         value: /[0-9a-zA-Z]+/
-                                       }
+        command.option :alpha_numeric, desc: 'Searches for all alphanumeric characters' do
+          @pattern = /[0-9a-zA-Z]+/
+        end
 
-        command.option :hex, desc: 'Searches for all hexadecimal characters',
-                              value: {
-                                type: Regexp,
-                                value: /[0-9a-fA-F]+/
-                              }
+        command.option :hex, desc: 'Searches for all hexadecimal characters' do
+          @pattern = /[0-9a-fA-F]+/
+        end
 
-        command.option :uppercase_hex, desc: 'Searches for all uppercase hexadecimal characters',
-                                     value: {
-                                       type: Regexp,
-                                       value: /[0-9A-F]+/
-                                     }
+        command.option :uppercase_hex, desc: 'Searches for all uppercase hexadecimal characters' do
+          @pattern = /[0-9A-F]+/
+        end
 
-        command.option :lowercase_hex, desc: 'Searches for all lowercase hexadecimal characters',
-                                     value: {
-                                       type: Regexp,
-                                       value: /[0-9a-f]+/
-                                     }
+        command.option :lowercase_hex, desc: 'Searches for all lowercase hexadecimal characters' do
+          @pattern = /[0-9a-f]+/
+        end
       end
 
       #

--- a/spec/cli/commands/new/exploit_spec.rb
+++ b/spec/cli/commands/new/exploit_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+require 'ronin/cli/commands/new/exploit'
+
+describe Ronin::CLI::Commands::New::Exploit do
+  describe "command_name" do
+    subject { described_class }
+
+    it do
+      expect(subject.command_name).to eq('exploit')
+    end
+  end
+end

--- a/spec/cli/commands/new/http_listener_spec.rb
+++ b/spec/cli/commands/new/http_listener_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+require 'ronin/cli/commands/new/http_listener'
+
+describe Ronin::CLI::Commands::New::HttpListener do
+  describe "command_name" do
+    subject { described_class }
+
+    it do
+      expect(subject.command_name).to eq('http-listener')
+    end
+  end
+end

--- a/spec/cli/pattern_options_spec.rb
+++ b/spec/cli/pattern_options_spec.rb
@@ -39,6 +39,55 @@ describe Ronin::CLI::PatternOptions do
       expect(subject.options[:version_number].desc).to eq('Searches for all version numbers')
     end
 
+    it "must define a '--alpha' option" do
+      expect(subject.options[:alpha]).to_not be(nil)
+      expect(subject.options[:alpha].short).to be(nil)
+      expect(subject.options[:alpha].value).to be(nil)
+      expect(subject.options[:alpha].desc).to eq('Searches for all alphabetic characters')
+    end
+
+    it "must define a '--uppercase' option" do
+      expect(subject.options[:uppercase]).to_not be(nil)
+      expect(subject.options[:uppercase].short).to be(nil)
+      expect(subject.options[:uppercase].value).to be(nil)
+      expect(subject.options[:uppercase].desc).to eq('Searches for all uppercase alphabetic characters')
+    end
+
+    it "must define a '--lowercase' option" do
+      expect(subject.options[:lowercase]).to_not be(nil)
+      expect(subject.options[:lowercase].short).to be(nil)
+      expect(subject.options[:lowercase].value).to be(nil)
+      expect(subject.options[:lowercase].desc).to eq('Searches for all lowercase alphabetic characters')
+    end
+
+    it "must define a '--alpha-numeric' option" do
+      expect(subject.options[:alpha_numeric]).to_not be(nil)
+      expect(subject.options[:alpha_numeric].short).to be(nil)
+      expect(subject.options[:alpha_numeric].value).to be(nil)
+      expect(subject.options[:alpha_numeric].desc).to eq('Searches for all alphanumeric characters')
+    end
+
+    it "must define a '--hex' option" do
+      expect(subject.options[:hex]).to_not be(nil)
+      expect(subject.options[:hex].short).to be(nil)
+      expect(subject.options[:hex].value).to be(nil)
+      expect(subject.options[:hex].desc).to eq('Searches for all hexadecimal characters')
+    end
+
+    it "must define a '--uppercase-hex' option" do
+      expect(subject.options[:uppercase_hex]).to_not be(nil)
+      expect(subject.options[:uppercase_hex].short).to be(nil)
+      expect(subject.options[:uppercase_hex].value).to be(nil)
+      expect(subject.options[:uppercase_hex].desc).to eq('Searches for all uppercase hexadecimal characters')
+    end
+
+    it "must define a '--lowercase-hex' option" do
+      expect(subject.options[:lowercase_hex]).to_not be(nil)
+      expect(subject.options[:lowercase_hex].short).to be(nil)
+      expect(subject.options[:lowercase_hex].value).to be(nil)
+      expect(subject.options[:lowercase_hex].desc).to eq('Searches for all lowercase hexadecimal characters')
+    end
+
     #
     # Language pattern options
     #


### PR DESCRIPTION

Added a spec for the HttpListener command to confirm its name is set to 'http-listener'.





