### PR TITLE
Restore TruffleRuby on CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,8 +13,7 @@ jobs:
           - '3.2'
           - '3.3'
           # - jruby
-          # NOTE: temporarily disable truffleruby due to weird rspec issue
-          # - truffleruby
+          - truffleruby
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v4

--- a/spec/cli/commands/dns_proxy_spec.rb
+++ b/spec/cli/commands/dns_proxy_spec.rb
@@ -124,16 +124,9 @@ describe Ronin::CLI::Commands::DnsProxy do
         let(:name) { '/[abc/' }
 
         it "must raise an OptionParser::InvalidArgument" do
-          # XXX: TruffleRuby's RegexpError exception message is different
-          if RUBY_ENGINE == 'truffleruby'
-            expect {
-              subject.parse_record_name(name)
-            }.to raise_error(OptionParser::InvalidArgument,"invalid argument: invalid Regexp: premature end of char-class (org.joni.exception.SyntaxException): /[abc/")
-          else
-            expect {
-              subject.parse_record_name(name)
-            }.to raise_error(OptionParser::InvalidArgument,"invalid argument: invalid Regexp: premature end of char-class: /[abc/")
-          end
+          expect {
+            subject.parse_record_name(name)
+          }.to raise_error(OptionParser::InvalidArgument,"invalid argument: invalid Regexp: premature end of char-class: /[abc/")
         end
       end
     end
@@ -196,16 +189,9 @@ describe Ronin::CLI::Commands::DnsProxy do
         let(:name) { '/[abc/' }
 
         it "must raise an OptionParser::InvalidArgument" do
-          # XXX: TruffleRuby's RegexpError exception message is different
-          if RUBY_ENGINE == 'truffleruby'
-            expect {
-              subject.parse_rule(rule)
-            }.to raise_error(OptionParser::InvalidArgument,"invalid argument: invalid Regexp: premature end of char-class (org.joni.exception.SyntaxException): /[abc/")
-          else
-            expect {
-              subject.parse_rule(rule)
-            }.to raise_error(OptionParser::InvalidArgument,"invalid argument: invalid Regexp: premature end of char-class: /[abc/")
-          end
+          expect {
+            subject.parse_rule(rule)
+          }.to raise_error(OptionParser::InvalidArgument,"invalid argument: invalid Regexp: premature end of char-class: /[abc/")
         end
       end
     end


### PR DESCRIPTION
Changes:
- fixed specs on TruffleRuby
- run specs on TruffleRuby on CI

### Notes

The failing specs expected exceptions to be raised with TruffleRuby specific messages. The Regexp related messages were fixed in the last TruffleRuby release 24.1 (in https://github.com/oracle/truffleruby/pull/3594) so it's now safe to remove these TruffleRuby specific expectations.